### PR TITLE
feat: add hour function and update docs about it

### DIFF
--- a/docs/time/hour.md
+++ b/docs/time/hour.md
@@ -1,27 +1,51 @@
 # hour
 
-```js
+## ES Module
+
+```ts
+// tree-shakeable import
+import { hour } from "chance";
+
 // usage
-chance.hour()
-chance.hour({twentyfour: true})
+hour({min?, max?, twentyfour?}?, seed?)
+
+//Example
+//returns 10
+hour() 
 ```
 
-Generate a random hour
+Returns a random hour.
 
-```js
-chance.hour();
-=> 9
-```
-
-By default, returns an hour from 1 to 12 for a standard [12-hour clock][12h].
+By default, returns an hour from 0 to 11 for a standard [12-hour clock][12h].
 
 Can optionally specify a full twenty-four.
 
-```js
-chance.hour({twentyfour: true});
-=> 21
+```ts
+// returns 21(between 0 and 23)
+hour({twentyfour: true});
 ```
 
-This will return an hour from 1 to 24.
+This will return an hour from 0 to 23.
 
-[12h]: https://en.wikipedia.org/wiki/12-hour_clock
+Also, you can specify the mininum hour and maximum hour that you want generate.
+
+```ts
+// returns 15(between 10 and 20)
+hour({min:10, max: 20, twentyfour: true});
+```
+
+## Class Instantiation
+
+Alternatively, you can create an instance of a `Chance` class and call the `hour` method.
+This approach avoids instantiating a new PRNG instance on every function call.
+
+```ts
+// import the Chance class
+import { Chance } from "chance";
+
+const chance = new Chance("my-random-seed");
+
+//Example
+//returns 10
+chance.hour()
+```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "packages/character",
     "packages/letter",
     "packages/hex",
+    "packages/hour",
     "packages/chance"
   ],
   "engines": {

--- a/packages/chance/src/index.ts
+++ b/packages/chance/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 // plop-imports
+import { HourGenerator, HourOptions } from "@chancejs/hour";
 import { LetterGenerator, LetterOptions } from "@chancejs/letter";
 import { HexGenerator, HexOptions } from "@chancejs/hex";
 import { FloatingGenerator, FloatingOptions } from "@chancejs/floating";
@@ -19,6 +20,7 @@ import { FalsyGenerator, FalsyOptions, Falsy } from "@chancejs/falsy";
 
 export class Chance implements IChance {
   // plop-class-fields
+  private hourGenerator: HourGenerator;
   private letterGenerator: LetterGenerator;
   private hexGenerator: HexGenerator;
   private floatingGenerator: FloatingGenerator;
@@ -39,6 +41,7 @@ export class Chance implements IChance {
     }
     const generator = options?.generator;
     // plop-constructor
+    this.hourGenerator = new HourGenerator({ seed, generator });
     this.letterGenerator = new LetterGenerator({ seed, generator });
     this.hexGenerator = new HexGenerator({ seed, generator });
     this.floatingGenerator = new FloatingGenerator({ seed, generator });
@@ -109,6 +112,10 @@ export class Chance implements IChance {
 
   falsy(options?: FalsyOptions): Falsy {
     return this.falsyGenerator.falsy(options);
+  }
+
+  hour(options?: HourOptions): number {
+    return this.hourGenerator.hour(options);
   }
 }
 

--- a/packages/chance/src/interfaces.ts
+++ b/packages/chance/src/interfaces.ts
@@ -1,4 +1,5 @@
 // plop-interface-imports
+import { IHourGenerator } from "@chancejs/hour";
 import { ILetterGenerator } from "@chancejs/letter";
 import { IHexGenerator } from "@chancejs/hex";
 import { IFloatingGenerator } from "@chancejs/floating";
@@ -33,6 +34,7 @@ export interface ChanceOptions {
 
 export type IChance = IRandomNumberGenerator &
   // plop-interface-union
+  IHourGenerator &
   ILetterGenerator &
   IHexGenerator &
   IFloatingGenerator &

--- a/packages/chance/src/time/hour.test.ts
+++ b/packages/chance/src/time/hour.test.ts
@@ -1,0 +1,203 @@
+import Chance from "..";
+import { times } from "@chancejs/generator";
+
+describe("::Chance ::Time ::#hour", () => {
+  let chance: Chance;
+  beforeEach(() => {
+    chance = new Chance();
+  });
+  describe("When executes hour", () => {
+    describe("without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour();
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 11).toBe(true);
+        });
+      });
+    });
+    describe("with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 23).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour only with min argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ min: 7 });
+          expect(typeof h).toBe("number");
+          expect(h >= 7).toBe(true);
+          expect(h <= 11).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ min: 15, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 15).toBe(true);
+          expect(h <= 23).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour only with max argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ max: 6 });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 6).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ max: 22, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 22).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour with min and max arguments", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ min: 1, max: 6 });
+          expect(typeof h).toBe("number");
+          expect(h >= 1).toBe(true);
+          expect(h <= 6).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = chance.hour({ min: 18, max: 20, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 18).toBe(true);
+          expect(h <= 20).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being smaller than min standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: -1 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: -1, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with max argument being smaller than min standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ max: -1 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ max: -1, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with max argument being greater than max standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ max: 13 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ max: 24, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being greater than max standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: 12 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: 25, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being greater than max argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: 8, max: 4 });
+          expect(fn).toThrow("Chance: Min cannot be greater than Max.");
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => chance.hour({ min: 18, max: 15, twentyfour: true });
+          expect(fn).toThrow("Chance: Min cannot be greater than Max.");
+        });
+      });
+    });
+  });
+});

--- a/packages/hour/jest.config.json
+++ b/packages/hour/jest.config.json
@@ -1,0 +1,13 @@
+{
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "globals": {
+    "ts-jest": {
+      "tsconfig": "tsconfig.test.json"
+    }
+  },
+  "modulePathIgnorePatterns": ["lib/*"],
+  "moduleNameMapper": {
+    "src/(.*)": "<rootDir>/src/$1"
+  }
+}

--- a/packages/hour/package.json
+++ b/packages/hour/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@chancejs/chance",
+  "name": "@chancejs/hour",
   "version": "1.0.0",
-  "description": "Chance - Utility library to generate anything random.",
+  "description": "Generate a random hour with Chance.js.",
   "homepage": "https://chancejs.com/",
   "author": "Victor Quinn <mail@victorquinn.com>",
   "main": "./lib/cjs/index.js",
@@ -36,15 +36,6 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@chancejs/bool": "1.0.0",
-    "@chancejs/character": "1.0.0",
-    "@chancejs/falsy": "1.0.0",
-    "@chancejs/floating": "1.0.0",
-    "@chancejs/generator": "1.0.0",
-    "@chancejs/hex": "1.0.0",
-    "@chancejs/integer": "1.0.0",
-    "@chancejs/letter": "1.0.0",
-    "@chancejs/natural": "1.0.0",
-    "@chancejs/hour": "1.0.0"
+    "@chancejs/generator": "1.0.0"
   }
 }

--- a/packages/hour/src/function.test.ts
+++ b/packages/hour/src/function.test.ts
@@ -1,0 +1,199 @@
+import { times } from "@chancejs/generator";
+import { hour } from "./function";
+
+describe("::Time ::hour()", () => {
+  describe("When executes hour", () => {
+    describe("without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour();
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 11).toBe(true);
+        });
+      });
+    });
+    describe("with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 23).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour only with min argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ min: 7 });
+          expect(typeof h).toBe("number");
+          expect(h >= 7).toBe(true);
+          expect(h <= 11).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ min: 15, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 15).toBe(true);
+          expect(h <= 23).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour only with max argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ max: 6 });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 6).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ max: 22, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 0).toBe(true);
+          expect(h <= 22).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour with min and max arguments", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ min: 1, max: 6 });
+          expect(typeof h).toBe("number");
+          expect(h >= 1).toBe(true);
+          expect(h <= 6).toBe(true);
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns correct result", () => {
+        times(1000, () => {
+          let h = hour({ min: 18, max: 20, twentyfour: true });
+          expect(typeof h).toBe("number");
+          expect(h >= 18).toBe(true);
+          expect(h <= 20).toBe(true);
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being smaller than min standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: -1 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: -1, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with max argument being smaller than min standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ max: -1 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ max: -1, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with max argument being greater than max standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ max: 13 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ max: 24, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being greater than max standard clock", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: 12 });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: 25, twentyfour: true });
+          expect(fn).toThrow(
+            "Chance: Min and Max values must be in clock interval."
+          );
+        });
+      });
+    });
+  });
+  describe("When executes hour with min argument being greater than max argument", () => {
+    describe("and without twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: 8, max: 4 });
+          expect(fn).toThrow("Chance: Min cannot be greater than Max.");
+        });
+      });
+    });
+    describe("and with twentyfour argument", () => {
+      it("returns error", () => {
+        times(1000, () => {
+          let fn = () => hour({ min: 18, max: 15, twentyfour: true });
+          expect(fn).toThrow("Chance: Min cannot be greater than Max.");
+        });
+      });
+    });
+  });
+});

--- a/packages/hour/src/function.ts
+++ b/packages/hour/src/function.ts
@@ -1,0 +1,10 @@
+import { HourGenerator } from "./generator";
+import { HourGeneratorFunction, HourOptions } from "./interfaces";
+
+export const hour: HourGeneratorFunction = (
+  options?: HourOptions,
+  seed?: number
+): number => {
+  const hourGenerator = new HourGenerator({ seed });
+  return hourGenerator.hour(options);
+};

--- a/packages/hour/src/generator.ts
+++ b/packages/hour/src/generator.ts
@@ -1,0 +1,43 @@
+import { Generator } from "@chancejs/generator";
+import { natural } from "@chancejs/natural";
+import { HourOptions, IHourGenerator } from "./interfaces";
+
+export class HourGenerator extends Generator implements IHourGenerator {
+  public hour(options: HourOptions = {}): number {
+    const { twentyfour, min, max } = options;
+    
+    const clockType = twentyfour ? 'twentyfour' : 'twelve';
+    const clockValues = {
+      twentyfour: {
+        min: 0,
+        max: 23
+      },
+      twelve: {
+        min: 0,
+        max: 11
+      },
+    };
+
+    const standardClock = clockValues[clockType];
+    const minHour = min ?? standardClock.min;
+    const maxHour = max ?? standardClock.max;
+    
+    this.testRange(minHour < standardClock.min ||
+                   maxHour < standardClock.min ||
+                   minHour > standardClock.max ||
+                   maxHour > standardClock.max, 
+                   "Chance: Min and Max values must be in clock interval.");
+    this.testRange(
+      minHour > maxHour,
+      "Chance: Min cannot be greater than Max."
+    );
+
+    return natural({ min: minHour, max: maxHour });
+  }
+
+  private testRange(test: boolean, errorMessage: string) {
+    if (test) {
+      throw new RangeError(errorMessage);
+    }
+  }
+}

--- a/packages/hour/src/index.ts
+++ b/packages/hour/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./interfaces";
+export * from "./function";
+export * from "./generator";

--- a/packages/hour/src/interfaces.ts
+++ b/packages/hour/src/interfaces.ts
@@ -1,0 +1,32 @@
+export interface HourOptions {
+  twentyfour?: boolean;
+  min?: number;
+  max?: number;
+}
+
+export interface HourGeneratorFunction {
+  /**
+   * Return a random hour.
+   *
+   * @param { HourOptions} [options={}]
+   * @param options.max - its represents max value that hour can have
+   * @param options.min - its represents min value that hour can have
+   * @param options.twentyfour - its a boolean that represents with hour is in twentyfour clock format(between 0 and 23 hours)
+   * @param {number} [seed] A numeric seed to pass to the pseudo-random number generator.
+   * @return { number }
+   * @example
+   * // returns 9
+   * hour()
+   * 
+   * // returns 15
+   * hour({twentyfour: true})
+   * 
+   * // returns 6
+   * hour({min: 5, max: 8})
+   */
+  (options?: HourOptions, seed?: number): number;
+}
+
+export interface IHourGenerator {
+  hour: HourGeneratorFunction;
+}

--- a/packages/hour/tsconfig-cjs.json
+++ b/packages/hour/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/packages/hour/tsconfig.json
+++ b/packages/hour/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2020",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "./lib/esm",
+    "declaration": true,
+    "moduleResolution": "node",
+    "paths": {
+      "src/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/hour/tsconfig.test.json
+++ b/packages/hour/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
## What changed, and why?
- Was added hour function.
- Change docs about hour function.
- Change 12-hour clock values from {min: 1, max: 12} to {min: 0, max: 11}, because 12-hour clock only works with hours between 0 and 11. 
See reference: https://en.wikipedia.org/wiki/12-hour_clock
## How is this tested?
All the tests passed and further tests were required for this new feature.